### PR TITLE
[SW-3230] Simplify prebaked node naming

### DIFF
--- a/synchros2/test/test_process.py
+++ b/synchros2/test/test_process.py
@@ -118,3 +118,15 @@ def test_cli_configuration() -> None:  # type: ignore
     with mock.patch("synchros2.scope.logs_to_ros") as logs_to_ros:
         assert main(["test_command", "spot", "--quiet"]) == 0
     assert not logs_to_ros.called
+
+
+def test_process_with_custom_name() -> None:
+    """Asserts that the process can be given a custom name."""
+
+    @process.main(name="my_node")
+    def main() -> int:
+        assert main.node is not None
+        assert main.node.get_fully_qualified_name() == "/my_node"
+        return 0
+
+    assert main() == 0


### PR DESCRIPTION
## Proposed changes

<!-- 
    A brief description of the changes you are making. 
    Make sure to refer to the issue that explains and
    motivates this patch.
-->

This patch simplifies the whole naming story for the implicit node in `ros_process`.

### Checklist

<!-- Mark each checkbox as you make progress in your contribution. -->

- [x] Lint and unit tests pass locally
- [x] I have added tests that prove my changes are effective
- [x] I have added necessary documentation to communicate the changes

