### PR TITLE
Bump timeout in test that was being flaky

### DIFF
--- a/synchros2/test/test_logging.py
+++ b/synchros2/test/test_logging.py
@@ -86,7 +86,7 @@ def test_log_forwarding(verbose_ros: ROSAwareScope) -> None:
         logger.propagate = True  # ensure propagation is enabled
         logger.info("test")
 
-    log = unwrap_future(rosout.update, timeout_sec=5.0)
+    log = unwrap_future(rosout.update, timeout_sec=15.0)
     expected_level = Log.INFO
     if isinstance(expected_level, bytes):
         # NOTE(hidmic): log levels are of bytestring type in earlier distros


### PR DESCRIPTION
## Proposed changes

This was being flaky e.g. https://github.com/bdaiinstitute/ros_utilities/runs/54227616709 and looked like maybe just a timeout issue.

### Checklist

<!-- Mark each checkbox as you make progress in your contribution. -->

- [x] Lint and unit tests pass locally
- [x] I have added tests that prove my changes are effective
- [x] I have added necessary documentation to communicate the changes

### Additional comments

<!-- Anything else worth mentioning. -->
