### PR TITLE
[SW-2822] Rename repository to synchros2

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "ros_utilities dev container",
+  "name": "synchros2 dev container",
   "build": {
     "dockerfile": "Dockerfile",
     "context": "..",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: ros_utilities CI
+name: synchros2 CI
 
 on:
   pull_request:
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   lint:
-    name: Lint ros_utilities packages
+    name: Lint synchros2 packages
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
@@ -25,7 +25,7 @@ jobs:
       - name: Lint sources
         uses: pre-commit/action@v3.0.0
   prepare_container:
-    name: Prepare ros_utilities containers
+    name: Prepare synchros2 containers
     runs-on: ubuntu-22.04
     needs: lint
     strategy:
@@ -71,7 +71,7 @@ jobs:
           path: /tmp/${{ matrix.rosdistro }}_docker_image.tar
           retention-days: 7
   build_and_test:
-    name: Build and test ros_utilities packages
+    name: Build and test synchros2 packages
     runs-on: ubuntu-22.04
     needs: prepare_container
     strategy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!-- omit in toc -->
-# Contributing to `ros_utilities`
+# Contributing to `synchros2`
 
 First off, thanks for taking the time to contribute! ❤️
 
@@ -23,11 +23,11 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 
 ## I Have a Question
 
-Before you ask a question, it is best to search for existing [issues](https://github.com/bdaiinstitute/ros_utilities/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
+Before you ask a question, it is best to search for existing [issues](https://github.com/bdaiinstitute/synchros2/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
 
 If you then still feel the need to ask a question and need clarification, we recommend the following:
 
-- Open an [issue](https://github.com/utilities/ros_utilities/issues/new).
+- Open an [issue](https://github.com/utilities/synchros2/issues/new).
 - Provide as much context as you can about what you're running into.
 - Provide project and platform versions, depending on what seems relevant.
 
@@ -47,7 +47,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 
 - Make sure that you are using the latest version.
 - Determine if your bug is really a bug and not an error on your side. If you are looking for support, you might want to check [this section](#i-have-a-question)).
-- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/bdaiinstitute/ros_utilities/issues?q=label%3Abug).
+- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/bdaiinstitute/synchros2/issues?q=label%3Abug).
 - Collect information about the bug:
   - Stack trace (Traceback)
   - OS, ROS, Platform and Version (Windows, Linux, macOS, x86, ARM)
@@ -60,7 +60,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 
 We use GitHub issues to track bugs and errors. If you run into an issue with the project:
 
-- Open an [issue](https://github.com/bdaiinstitute/ros_utilities/issues/new).
+- Open an [issue](https://github.com/bdaiinstitute/synchros2/issues/new).
 - Explain the behavior you would expect and the actual behavior.
 - Please provide as much context as possible and describe the *reproduction steps* that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
 - Provide the information you collected in the previous section.
@@ -78,18 +78,18 @@ Once it's filed:
 
 - Make sure that you are using the latest version.
 - Read the documentation carefully and ensure the functionality is indeed missing.
-- Perform a [search](https://github.com/bdaiinstitute/ros_utilities/issues) to see if the feature has already been requested. If it has, add a comment to the existing issue instead of opening a new one.
+- Perform a [search](https://github.com/bdaiinstitute/synchros2/issues) to see if the feature has already been requested. If it has, add a comment to the existing issue instead of opening a new one.
 - Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
 
 <!-- omit in toc -->
 #### How Do I Submit a Good Feature Request?
 
-Feature requests are tracked as [GitHub issues](https://github.com/bdaiinstitute/ros_utilities/issues).
+Feature requests are tracked as [GitHub issues](https://github.com/bdaiinstitute/synchros2/issues).
 
 - Use a **clear and descriptive title** for the issue to identify the suggestion.
 - Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
 - **Describe the current behavior** and **explain which behavior you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
-- **Explain why this enhancement would be useful** to most `ros_utilities` users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
+- **Explain why this enhancement would be useful** to most `synchros2` users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
 
 <!-- You might want to create an issue template for enhancement suggestions that can be used as a guide and that defines the structure of the information to be included. If you do so, reference it here in the description. -->
 
@@ -104,14 +104,14 @@ Feature requests are tracked as [GitHub issues](https://github.com/bdaiinstitute
   ```sh
   mkdir -p path/to/workspace/src
   cd path/to/workspace/src
-  git clone https://github.com/user-name/ros_utilities.git
+  git clone https://github.com/user-name/synchros2.git
   cd -
   ```
   
 - Install `pre-commit` hooks for it:
 
   ```sh
-  cd path/to/workspace/src/ros_utilities
+  cd path/to/workspace/src/synchros2
   pip install pre-commit
   pre-commit install
   cd -
@@ -131,7 +131,7 @@ Standard ROS development practices apply: [`rosdep` to manage depedencies](https
 Standard [ROS documentation practices](https://docs.ros.org/en/humble/How-To-Guides/Documenting-a-ROS-2-Package.html) apply e.g.:
 
 ```sh
-cd path/to/workspace/src/ros_utilities/synchros2
+cd path/to/workspace/src/synchros2/synchros2
 rosdoc2 build -p .
 rosdoc2 open docs_output/synchros2
 ```

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-# `ros_utilities`
+# `synchros2`
 
-![Python Support](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10-blue)
+![Python Support](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue)
 ![ROS Support](https://img.shields.io/badge/ROS-humble%20%7C%20jazzy-blue)
 
 ## Overview
 
-`ros_utilities` enable a different, at times simpler approach to ROS 2 programming, particularly for those that come with a ROS 1 background.  See the [synchros2 README](synchros2/README.md) for more information.
+`synchros2` enables a different, at times simpler approach to ROS 2 programming, particularly for those that come with a ROS 1 background.  See the [`synchros2` README](synchros2/README.md) for more information.
 
 ## Packages
 
 This repository contains the following packages:
 
-| Package                             | Description                                                                        |
-|-------------------------------------| -----------------------------------------------------------------------------------|
-| [`synchros2`](synchros2)            | `rclpy` wrappers to ease idiomatic, synchronous ROS 2 programming in Python.       |
-
-**Note**: `proto2ros` packages for Protobuf / ROS 2 interoperability used to live in this repository but now live in https://github.com/bdaiinstitute/proto2ros.
+| Package                                                                             | Description                                                                   |
+|-------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
+| [`synchros2`](synchros2)                                                            | `rclpy` wrappers to ease idiomatic, synchronous ROS 2 programming in Python.  |
+| [`synchros2_tutorials_example`](synchros2_tutorials_example)                        | Support code for `synchros2` tutorials.                                       |
+| [`synchros2_tutorials_interfaces_example`](synchros2_tutorials_interfaces_example)  | Support interfaces for `synchros2` tutorials.                                 |
 
 ## Next steps
 

--- a/synchros2/docs/concepts/message_feeds.md
+++ b/synchros2/docs/concepts/message_feeds.md
@@ -12,7 +12,7 @@ Any message filter can become a feed, allowing:
 
 Like message filters, most message feeds can be chained. This is true for all but those that externally source messages, ROS 2 topic subscriptions being the prime example. These are sources only. Other message feeds built into `synchros2` offer a vehicle for generic map-filter-reduce patterns, time synchronization across multiple message feeds, and synchronized `tf` lookups.
 
-**Note:** While any message filter can become a feed, standard ROS 2 message filters are usually not thread-safe. See [`synchros2.filters`](https://github.com/bdaiinstitute/ros_utilities/tree/main/synchros2/synchros2/filters.py) for thread-safe (re)implementations.
+**Note:** While any message filter can become a feed, standard ROS 2 message filters are usually not thread-safe. See [`synchros2.filters`](https://github.com/bdaiinstitute/synchros2/tree/main/synchros2/synchros2/filters.py) for thread-safe (re)implementations.
 
 ## Looping over topic messages
 

--- a/synchros2/docs/getting_started/installation.md
+++ b/synchros2/docs/getting_started/installation.md
@@ -13,7 +13,7 @@ These links are to Humble tutorials but `synchros2` should be compatible with an
     
     ```bash
     cd <workspace>/src
-    git clone https://github.com/bdaiinstitute/ros_utilities.git
+    git clone https://github.com/bdaiinstitute/synchros2.git
     ```
     
 2. Build and source the colcon workspace


### PR DESCRIPTION
## Proposed changes

<!-- 
    A brief description of the changes you are making. 
    Make sure to refer to the issue that explains and
    motivates this patch.
-->

This patch replaces all references to the `ros_utilities` repository with references to the `synchros2` repository, following repository rename to comply with [REP-144](https://www.ros.org/reps/rep-0144.html).

### Checklist

<!-- Mark each checkbox as you make progress in your contribution. -->

- [x] Lint and unit tests pass locally
- [x] I have added tests that prove my changes are effective
- [x] I have added necessary documentation to communicate the changes
