### PR TITLE
[N/A] tf2_ros is tf2_ros_py for Python

### DIFF
--- a/synchros2/package.xml
+++ b/synchros2/package.xml
@@ -12,7 +12,7 @@
   <exec_depend>launch</exec_depend>
   <exec_depend>message_filters</exec_depend>
   <exec_depend>rclpy</exec_depend>
-  <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>tf2_ros_py</exec_depend>
   <exec_depend>tf2_msgs</exec_depend>
 
   <test_depend>example_interfaces</test_depend>


### PR DESCRIPTION
## Proposed changes

<!-- 
    A brief description of the changes you are making. 
    Make sure to refer to the issue that explains and
    motivates this patch.
-->

Follow-up to #183. `tf2_ros`, the ROS package, doesn't bring `tf2_ros`, the Python module. `tf2_ros_py` does.

### Checklist

<!-- Mark each checkbox as you make progress in your contribution. -->

- [x] Lint and unit tests pass locally
- [x] I have added tests that prove my changes are effective
- [x] I have added necessary documentation to communicate the changes
