### PR TITLE
Minor migration guide fix

### DIFF
--- a/synchros2/docs/guides/rclpy_migration.md
+++ b/synchros2/docs/guides/rclpy_migration.md
@@ -40,16 +40,16 @@ import synchros2.process as ros_process
 from synchros2.node import Node
 
 class MyNode(Node):
-	def __init__(self) -> None:
-		super().__init__('my_node')
-		# ... setup publishers, timers, etc ...
+    def __init__(self, **kwargs) -> None:
+        super().__init__('my_node', **kwargs)
+        # ... setup publishers, timers, etc ...
 
 @ros_process.main(prebaked=False)
 def main() -> None:
     ros_process.spin(MyNode)
 
 if __name__ == '__main__':
-	main()
+    main()
 ```
 
 And if single-threaded execution is (still) a must to ensure equivalent behavior:
@@ -62,8 +62,8 @@ from synchros2.executors import foreground
 from synchros2.node import Node
 
 class MyNode(Node):
-	def __init__(self) -> None:
-		super().__init__('my_node')
+    def __init__(self, **kwargs) -> None:
+        super().__init__('my_node', **kwargs)
 		# ... setup publishers, timers, etc ...
 
 @ros_process.main(prebaked=False)
@@ -72,5 +72,5 @@ def main() -> None:
         main.spin(MyNode)
 
 if __name__ == '__main__':
-	main()
+    main()
 ```


### PR DESCRIPTION
## Proposed changes

I tried the example code in the [migration guide](https://docs.ros.org/en/ros2_packages/humble/api/synchros2/guides/rclpy_migration.html) and got this error:

```
  File "<...>/synchros2/scope.py", line 372, in load
    node_or_graph = factory(*args, context=self._context, namespace=namespace, **kwargs)
TypeError: MyNode.__init__() got an unexpected keyword argument 'context'
```

I think `**kwargs` needs to be added to pass the context through `synchros2`. I made a minor mod to the guide accordingly.

While there I also changed some tabs to spaces. 

End result (running the example in the guide with a logging statement added for vis)
```py
import synchros2.process as ros_process
from synchros2.node import Node

class MyNode(Node):
    def __init__(self, **kwargs) -> None:
        super().__init__('my_node', **kwargs)
        # ... setup publishers, timers, etc ...
        self.get_logger().info("MyNode has been initialized!")

@ros_process.main(prebaked=False)
def main() -> None:
    ros_process.spin(MyNode)

if __name__ == '__main__':
    main()
```
```
[INFO] [1769459126.562192779] [my_node]: MyNode has been initialized!
```

### Checklist

<!-- Mark each checkbox as you make progress in your contribution. -->

- [X] Lint and unit tests pass locally
- [ ] I have added tests that prove my changes are effective
- [ ] I have added necessary documentation to communicate the changes

### Additional comments

<!-- Anything else worth mentioning. -->
