### PR TITLE
Handle missing `typing.override`

### DIFF
--- a/synchros2/synchros2/node.py
+++ b/synchros2/synchros2/node.py
@@ -6,8 +6,7 @@ from typing import Any, Callable, Iterable, Optional, Type
 try:
     from typing import override  # type: ignore[attr-defined]
 except ImportError:
-    from typing_extensions import override  # type: ignore[import]
-
+    override = lambda func: func  # noqa
 
 from rclpy.callback_groups import CallbackGroup
 from rclpy.clock import Clock

--- a/synchros2/synchros2/time.py
+++ b/synchros2/synchros2/time.py
@@ -7,7 +7,7 @@ from typing import Optional, Union
 try:
     from typing import override  # type: ignore[attr-defined]
 except ImportError:
-    from typing_extensions import override  # type: ignore[import]
+    override = lambda func: func  # noqa
 
 from rclpy.context import Context
 from rclpy.duration import Duration


### PR DESCRIPTION
## Proposed changes

Follow-up to #203. There is no `typing.override` back in Python 3.10, and the `typing_extensions` version distributed with Ubuntu Jammy is old enough to lack a forward port. This patch just replaces it with an identity decorator.

### Checklist

<!-- Mark each checkbox as you make progress in your contribution. -->

- [x] Lint and unit tests pass locally
- [ ] I have added tests that prove my changes are effective
- [ ] I have added necessary documentation to communicate the changes
